### PR TITLE
Allocate a receiving thread and a sending thread for the RPC Client.

### DIFF
--- a/src/main/java/com/celeral/netlet/DefaultEventLoop.java
+++ b/src/main/java/com/celeral/netlet/DefaultEventLoop.java
@@ -339,6 +339,7 @@ public class DefaultEventLoop implements Runnable, EventLoop
         sc.configureBlocking(false);
         final ServerListener sl = (ServerListener)sk.attachment();
         final ClientListener l = sl.getClientConnection(sc, (ServerSocketChannel)sk.channel());
+        l.connected();
         register(sc, SelectionKey.OP_READ | SelectionKey.OP_WRITE, l);
         break;
 
@@ -456,13 +457,6 @@ public class DefaultEventLoop implements Runnable, EventLoop
     });
   }
 
-  //@Override
-  public void register(ServerSocketChannel channel, Listener l)
-  {
-    register(channel, SelectionKey.OP_ACCEPT, l);
-  }
-
-  //@Override
   public void register(SocketChannel channel, int ops, Listener l)
   {
     register((AbstractSelectableChannel)channel, ops, l);
@@ -603,6 +597,7 @@ public class DefaultEventLoop implements Runnable, EventLoop
                 else {
                   try {
                     key.attach(Listener.NOOP_CLIENT_LISTENER);
+                    l.disconnected();
                     key.channel().close();
                   }
                   catch (IOException io) {

--- a/src/main/java/com/celeral/netlet/OptimizedEventLoop.java
+++ b/src/main/java/com/celeral/netlet/OptimizedEventLoop.java
@@ -116,7 +116,7 @@ public class OptimizedEventLoop extends DefaultEventLoop
 
   }
 
-  @SuppressWarnings({"UseSpecificCatch"})
+  @SuppressWarnings({"UseSpecificCatch", "deprecation"})
   OptimizedEventLoop(String id, int taskBufferSize) throws IOException
   {
     super(id, taskBufferSize);

--- a/src/main/java/com/celeral/netlet/codec/StatefulStreamCodec.java
+++ b/src/main/java/com/celeral/netlet/codec/StatefulStreamCodec.java
@@ -16,15 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package com.celeral.netlet.codec;
 
 import com.celeral.netlet.util.Slice;
 
 /**
- * <p>StatefulStreamCodec interface.</p>
+ * <p>
+ * StatefulStreamCodec interface.</p>
  *
  * @param <T>
+ *
  * @since 0.3.2
  */
 public interface StatefulStreamCodec<T>
@@ -58,12 +59,20 @@ public interface StatefulStreamCodec<T>
      * the accompanying data field may not make it to the deserializer.
      */
     public Slice state;
+
+    @Override
+    public String toString()
+    {
+      return "DataStatePair{" + "data=" + data + ", state=" + state + '}';
+    }
+
   }
 
   /**
    * Create POJO from the byte array for consumption by the downstream.
    *
    * @param dspair
+   *
    * @return plain old java object, the type is intentionally not T since the consumer does not care for it.
    */
   Object fromDataStatePair(DataStatePair dspair);
@@ -73,6 +82,7 @@ public interface StatefulStreamCodec<T>
    * it can be transmitted or stored in file
    *
    * @param object plain old java object
+   *
    * @return serialized representation of the object
    */
   DataStatePair toDataStatePair(T object);
@@ -87,13 +97,13 @@ public interface StatefulStreamCodec<T>
    */
   void resetState();
 
-
   static class Synchronized
   {
     static class $tatefulStreamCodec<T> implements com.celeral.netlet.codec.StatefulStreamCodec<T>
     {
       private final StatefulStreamCodec<T> codec;
       private final Object mutex;
+
       $tatefulStreamCodec(StatefulStreamCodec<T> codec, Object mutex)
       {
         this.mutex = mutex;

--- a/src/test/java/com/celeral/netlet/rpc/RPCTest.java
+++ b/src/test/java/com/celeral/netlet/rpc/RPCTest.java
@@ -1,4 +1,4 @@
-  /*
+/*
  * Copyright 2017 Celeral <netlet@celeral.com>.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,10 +26,10 @@ import com.celeral.netlet.AbstractServer;
 import com.celeral.netlet.DefaultEventLoop;
 import com.celeral.netlet.rpc.ConnectionAgent.SimpleConnectionAgent;
 import com.celeral.netlet.rpc.ProxyClient.ExecutingClient;
-import java.util.concurrent.Executors;
 
 import org.junit.Assert;
 import org.junit.Test;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +43,7 @@ public class RPCTest
   public static interface HelloWorld
   {
     void greet();
+
     boolean hasGreeted();
   }
 
@@ -71,6 +72,7 @@ public class RPCTest
   public static class Server extends AbstractServer
   {
     private final boolean multithreaded;
+
     public Server(boolean multithreaded)
     {
       this.multithreaded = multithreaded;
@@ -80,8 +82,8 @@ public class RPCTest
     public ClientListener getClientConnection(SocketChannel client, ServerSocketChannel server)
     {
       return multithreaded
-             ? new ExecutingClient(new HelloWorldImpl(), new Class<?>[] {HelloWorld.class}, Executors.newFixedThreadPool(10))
-             : new ExecutingClient(new HelloWorldImpl(), new Class<?>[] {HelloWorld.class});
+      ? new ExecutingClient(new HelloWorldImpl(), new Class<?>[]{HelloWorld.class}, 10)
+      : new ExecutingClient(new HelloWorldImpl(), new Class<?>[]{HelloWorld.class});
     }
 
     @Override
@@ -94,7 +96,6 @@ public class RPCTest
     }
 
   }
-
 
   @Test
   public void testRPCMultiThreaded() throws IOException, InterruptedException
@@ -125,17 +126,22 @@ public class RPCTest
 
       try {
         ProxyClient client = new ProxyClient(new SimpleConnectionAgent((InetSocketAddress)si, el), TimeoutPolicy.NO_TIMEOUT_POLICY);
-        HelloWorld helloWorld = (HelloWorld)client.create(HelloWorld.class.getClassLoader(), new Class<?>[]{HelloWorld.class});
-        Assert.assertFalse("Before Greeted!", helloWorld.hasGreeted());
-
         try {
-          helloWorld.greet();
-        }
-        catch (RuntimeException ex) {
-          Assert.assertEquals("Hello World!", ex.getMessage());
-        }
+          HelloWorld helloWorld = (HelloWorld)client.create(HelloWorld.class.getClassLoader(), new Class<?>[]{HelloWorld.class});
+          Assert.assertFalse("Before Greeted!", helloWorld.hasGreeted());
 
-        Assert.assertTrue("After Greeted!", helloWorld.hasGreeted());
+          try {
+            helloWorld.greet();
+          }
+          catch (RuntimeException ex) {
+            Assert.assertEquals("Hello World!", ex.getMessage());
+          }
+
+          Assert.assertTrue("After Greeted!", helloWorld.hasGreeted());
+        }
+        finally {
+          client.close();
+        }
       }
       finally {
         el.stop(server);


### PR DESCRIPTION
Otherwise it can cause deadlock across the client-server processes.
Client make a RPC call, the server makes another RPC call to client
before returning a response to the client in the same thread causes
deadlock.